### PR TITLE
ci: notify mono repo on submodule update

### DIFF
--- a/.github/workflows/notify-mono.yml
+++ b/.github/workflows/notify-mono.yml
@@ -1,0 +1,17 @@
+name: Notify Mono Repo
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger mono submodule update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.MONO_DISPATCH_TOKEN }}
+          repository: Pawpaw-Technology/llm-wiki-mono
+          event-type: submodule-update
+          client-payload: '{"submodule": "agents", "repo": "${{ github.repository }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Add notify-mono.yml: on push to main, sends repository_dispatch to llm-wiki-mono. Requires MONO_DISPATCH_TOKEN secret.