### PR TITLE
feat: implement ingest.ts and lint.ts agents

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "classify": "tsx src/classify.ts",
-    "librarian": "tsx src/librarian.ts",
+    "ingest": "tsx src/ingest.ts",
     "lint": "tsx src/lint.ts"
   },
   "dependencies": {

--- a/prompts/ingest.md
+++ b/prompts/ingest.md
@@ -1,0 +1,97 @@
+You are a wiki ingest agent for a technical team's knowledge base.
+
+You will receive a raw source document and produce a complete wiki page for it, plus the metadata needed to update the index and cross-reference related pages.
+
+## Wiki Conventions
+
+{{conventions}}
+
+## Current Wiki Index
+
+The following index shows every page that already exists. Use it to:
+
+- Identify related pages to link from the new page's `related:` frontmatter and `## Related` body section
+- Detect whether a concept referenced in this source already has a concept page in `concepts/`
+- Avoid creating a slug that conflicts with an existing page
+
+```text
+{{index}}
+```
+
+## Source to Ingest
+
+**Source path:** `{{source_path}}`
+
+```
+{{source_content}}
+```
+
+## Your Task
+
+Produce a single wiki page for this source following the conventions above. Then output the structured JSON response described below.
+
+### Page Type Rules
+
+- If the source is an ADR, paper, or article: produce a **Source Summary** page.
+- If the source is a tweet or short social post: produce a **Tweet Digest** page.
+- Use the `sources:` frontmatter field to point back to `{{source_path}}`.
+- If the source is marked superseded (e.g., contains `[已取代]`), reflect that status prominently in the body.
+
+### Slug Rules
+
+- Slugify the page **title** (not the source filename): lowercase, spaces and special characters replaced with hyphens, Chinese characters preserved as-is.
+- Maximum **60 characters** for the slug (before `.md`). If the title is long, abbreviate to the core concept.
+- Examples: `ADR-013: R2 UAC 音频架构` → `adr-013-r2-uac-音频架构`, `AutoResearch 实战：嵌入式算法 7 轮迭代提升 20%` → `autoresearch-嵌入式算法实战`
+
+### Body Rules
+
+1. **First line of body**: one-sentence core takeaway that lets a reader decide whether to read further. No heading — plain prose.
+2. **Structured sections**: follow the section names from the conventions for this source type (ADRs: 背景/决策/关键设计/状态; papers: 核心贡献/方法/结论; articles: 主要观点/关键论据; tweets: inline prose, no sections required).
+3. **Inline `[[wikilinks]]`**: use `[[slug]]` or `[[slug|display text]]` wherever a concept is referenced in the body. Use the filename-without-extension of the target page as the slug. This is how concept page creation is triggered — do not skip this.
+4. **`## Related` body section**: always include at the end. List the most important related pages with `[[slug|Display Title]] — one-line annotation` format. This is the curated reading list; use it to explain _why_ each link matters, not just to repeat the title.
+
+### Decay Selection
+
+- `fast` — news, pricing, releases, social posts, time-bounded case studies
+- `normal` — analysis, methods, ADRs, architectural decisions
+- `slow` — fundamental concepts, evergreen references
+- `ephemeral` — noise tweets with minimal extractable knowledge
+
+### Category Selection
+
+| Category       | Content                                                  |
+| -------------- | -------------------------------------------------------- |
+| `architecture` | System design, patterns, attention, scaling laws         |
+| `training`     | ML training, fine-tuning, RLHF, data                     |
+| `infra`        | GPU, serving, distributed, quantization, deployment      |
+| `tools`        | Frameworks, SDKs, MCP, agents, prompting, coding tools   |
+| `product`      | Companies, model releases, pricing, competitive analysis |
+| `ops`          | ADRs, runbooks, operational decisions, processes         |
+
+Do NOT assign `concepts` — concept pages are created by the lint agent, not ingest.
+
+### Related Updates
+
+After creating the new page, identify existing wiki pages that should link back to it. For each such page, return its path (relative to `wiki/`) and the path of the new page to add to its `related:` frontmatter. Only include pages that are genuinely related — do not add noise entries.
+
+## Output
+
+Respond with ONLY a JSON object, no other text:
+
+```json
+{
+  "slug": "slug-derived-from-title-max-60-chars",
+  "category": "one of: architecture | training | infra | tools | product | ops",
+  "wiki_page_markdown": "complete markdown content of the new wiki page, including frontmatter",
+  "index_entry": "- [Page Title](category/slug.md) — one-line summary matching the takeaway",
+  "log_entry": "Ingested from {{source_path}}. Created source summary in <category>/.",
+  "related_updates": [
+    {
+      "path": "category/existing-page-slug.md",
+      "add_related": "category/new-page-slug.md"
+    }
+  ]
+}
+```
+
+Respond with ONLY the JSON object. No preamble, no explanation, no markdown fence around the outer JSON.

--- a/prompts/ingest.md
+++ b/prompts/ingest.md
@@ -94,4 +94,15 @@ Respond with ONLY a JSON object, no other text:
 }
 ```
 
+## Self-Validation Checklist
+
+Before outputting, verify:
+
+1. Your slug is ≤ 60 characters
+2. Your category is one of: architecture, training, infra, tools, product, ops (NOT concepts)
+3. Your wiki_page_markdown starts with `---` and has valid YAML frontmatter
+4. All newlines in your JSON string values are escaped as `\n`, not raw newlines
+5. Your index_entry follows the format `- [Title](category/slug.md) — summary`
+6. All `related_updates[].path` entries point to pages listed in the wiki index above
+
 Respond with ONLY the JSON object. No preamble, no explanation, no markdown fence around the outer JSON.

--- a/prompts/lint-fix.md
+++ b/prompts/lint-fix.md
@@ -1,0 +1,112 @@
+You are a wiki lint-fix agent for a technical team's knowledge base.
+
+You will operate in one of two modes. Read `{{mode}}` to determine which task applies.
+
+## Wiki Conventions
+
+{{conventions}}
+
+---
+
+## Mode A — Concept Page Creation
+
+**Active when:** `{{mode}}` is `concept`
+
+A concept slug has 3 or more wiki pages that reference it via `[[wikilink]]` mentions, but no dedicated concept page exists yet. Your job is to synthesize the referencing pages into a new concept page in `concepts/`.
+
+### Inputs (Mode A)
+
+**Concept slug:** `{{concept_slug}}`
+
+**Pages that reference this concept** (truncated to 300 chars each):
+
+```
+{{referencing_pages}}
+```
+
+### Task (Mode A)
+
+1. Choose a clear, concise English or Chinese title for the concept. Use the canonical name the team uses in their writing.
+2. Synthesize what the concept means _in the context of this team's work_ — not a generic definition. Pull insights from the referencing pages.
+3. Structure the page with relevant `##` sections appropriate to what the concept actually is.
+4. Include inline `[[wikilinks]]` to related concepts in the body.
+5. Include a `## Related` section listing the referencing pages with one-line annotations explaining how each relates to the concept.
+6. Set `decay: slow` — concept pages are evergreen by definition.
+7. Set `sources: []` — concept pages have no single raw source.
+
+### Output Schema (Mode A)
+
+Respond with ONLY a JSON object, no other text:
+
+```json
+{
+  "slug": "concept-slug-max-60-chars",
+  "category": "concepts",
+  "wiki_page_markdown": "complete markdown of the new concept page including frontmatter",
+  "index_entry": "- [Concept Title](concepts/concept-slug.md) — one-line summary of what this concept means to the team",
+  "log_entry": "Created concept page for '{{concept_slug}}' synthesized from N referencing pages.",
+  "related_updates": [
+    {
+      "path": "category/referencing-page.md",
+      "add_related": "concepts/concept-slug.md"
+    }
+  ]
+}
+```
+
+---
+
+## Mode B — TODO Stub Rewrite
+
+**Active when:** `{{mode}}` is `rewrite`
+
+A wiki page exists but contains TODO placeholders or an empty body. The raw source it was meant to summarize is available. Your job is to rewrite the page with full content.
+
+### Inputs (Mode B)
+
+**Current page content** (with TODO markers):
+
+```
+{{current_page}}
+```
+
+**Raw source content** (the document this page should summarize):
+
+```
+{{raw_source}}
+```
+
+### Task (Mode B)
+
+1. Preserve all frontmatter fields exactly as they are — do not change `title`, `tags`, `decay`, `sources`, `related`, or `category`. The slug is fixed.
+2. Replace the body (everything after the closing `---`) with a proper wiki page body:
+   - First line: one-sentence core takeaway (no heading).
+   - Structured sections appropriate to the source type (see conventions above).
+   - Inline `[[wikilinks]]` where concepts are referenced.
+   - `## Related` section at the end, cross-referencing pages already in `related:` frontmatter with annotations.
+3. Remove all `TODO` markers and placeholder text.
+4. Do not invent facts — if the raw source does not contain enough information for a section, omit that section rather than hallucinate.
+
+### Output Schema (Mode B)
+
+Respond with ONLY a JSON object, no other text:
+
+```json
+{
+  "wiki_page_markdown": "complete rewritten markdown including the preserved frontmatter",
+  "index_entry": "- [Page Title](category/slug.md) — updated one-line summary"
+}
+```
+
+---
+
+## General Rules (Both Modes)
+
+- Chinese content is expected — write in the language the source uses. Mixed Chinese/English is fine and common.
+- Do not alter `raw/` files — they are read-only.
+- `[[wikilinks]]` use the **filename without extension** as the slug. For disambiguation, use `[[slug|display text]]`.
+- Frontmatter `related:` paths are relative to `wiki/` (e.g., `ops/adr-013-....md`), not to the repo root.
+- Tags: lowercase, hyphenated (e.g., `algorithm-optimization`). Free-form — do not restrict to a fixed list.
+- Prefer fewer accurate tags over many vague ones.
+
+Respond with ONLY the JSON object. No preamble, no explanation, no markdown fence around the outer JSON.

--- a/src/classify.ts
+++ b/src/classify.ts
@@ -11,30 +11,21 @@
  *   npm run classify -- --batch 10 --dry-run       # preview 10 pages
  */
 
-import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { ClaudeCodeEngine } from "codebridge/src/engines/claude-code.js";
-import { KimiCodeEngine } from "codebridge/src/engines/kimi-code.js";
-import { CodexEngine } from "codebridge/src/engines/codex.js";
-import { OpenCodeEngine } from "codebridge/src/engines/opencode.js";
-import type { Engine } from "codebridge/src/core/engine.js";
+import {
+  WIKI_ROOT,
+  lw,
+  createEngine,
+  parseBaseArgs,
+  parseJsonResponse,
+  loadPrompt,
+  dispatchTask,
+} from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const PROMPT_TEMPLATE = readFileSync(
-  path.join(__dirname, "../prompts/classify.md"),
-  "utf-8",
-);
-
-const WIKI_ROOT =
-  process.env.LW_WIKI_ROOT ||
-  process.env.WIKI_ROOT ||
-  path.resolve(__dirname, "../../wiki");
 
 const CATEGORIES = [
   "architecture",
@@ -46,56 +37,8 @@ const CATEGORIES = [
 ];
 
 // ---------------------------------------------------------------------------
-// Args
+// Page I/O
 // ---------------------------------------------------------------------------
-
-interface Args {
-  engine: string;
-  model: string;
-  batch: number;
-  dryRun: boolean;
-}
-
-function parseArgs(): Args {
-  const args = process.argv.slice(2);
-  const opts: Args = {
-    engine: "claude-code",
-    model: "",
-    batch: 20,
-    dryRun: false,
-  };
-  for (let i = 0; i < args.length; i++) {
-    switch (args[i]) {
-      case "--engine":
-      case "-e":
-        opts.engine = args[++i];
-        break;
-      case "--model":
-      case "-m":
-        opts.model = args[++i];
-        break;
-      case "--batch":
-      case "-b":
-        opts.batch = parseInt(args[++i], 10);
-        break;
-      case "--dry-run":
-        opts.dryRun = true;
-        break;
-    }
-  }
-  return opts;
-}
-
-// ---------------------------------------------------------------------------
-// LW CLI helpers
-// ---------------------------------------------------------------------------
-
-function lw(cmd: string): string {
-  return execSync(`lw ${cmd} --root "${WIKI_ROOT}"`, {
-    encoding: "utf-8",
-    timeout: 30_000,
-  }).trim();
-}
 
 interface PageEntry {
   path: string;
@@ -124,27 +67,6 @@ function writePage(pagePath: string, content: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Engine factory
-// ---------------------------------------------------------------------------
-
-function createEngine(name: string): Engine {
-  switch (name) {
-    case "claude-code":
-      return new ClaudeCodeEngine();
-    case "kimi-code":
-      return new KimiCodeEngine();
-    case "codex":
-      return new CodexEngine();
-    case "opencode":
-      return new OpenCodeEngine();
-    default:
-      throw new Error(
-        `Unknown engine: ${name}. Supported: claude-code, kimi-code, codex, opencode`,
-      );
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Classification
 // ---------------------------------------------------------------------------
 
@@ -167,43 +89,16 @@ function buildPrompt(
     null,
     2,
   );
-  return PROMPT_TEMPLATE.replace(
-    "{{categories}}",
-    CATEGORIES.join(", "),
-  ).replace("{{pages}}", pagesJson);
-}
-
-function parseResponse(output: string): Classification[] {
-  // Try direct JSON parse
-  try {
-    return JSON.parse(output);
-  } catch {}
-
-  // Try markdown code block
-  const codeBlockMatch = output.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
-  if (codeBlockMatch) {
-    try {
-      return JSON.parse(codeBlockMatch[1]);
-    } catch {}
-  }
-
-  // Try bracket search
-  const start = output.indexOf("[");
-  const end = output.lastIndexOf("]");
-  if (start !== -1 && end > start) {
-    try {
-      return JSON.parse(output.slice(start, end + 1));
-    } catch {}
-  }
-
-  throw new Error("Could not parse LLM response as JSON array");
+  return loadPrompt("classify", {
+    categories: CATEGORIES.join(", "),
+    pages: pagesJson,
+  });
 }
 
 function updatePageFrontmatter(
   content: string,
   classification: Classification,
 ): string {
-  // Replace frontmatter fields
   let updated = content;
 
   // Update tags
@@ -214,7 +109,6 @@ function updatePageFrontmatter(
     } else if (updated.match(/^tags:\s*$/m)) {
       updated = updated.replace(/^tags:\s*$/m, `tags: ${tagStr}`);
     } else {
-      // Insert after title line
       updated = updated.replace(/^(title:.*\n)/m, `$1tags: ${tagStr}\n`);
     }
   }
@@ -242,7 +136,7 @@ function updatePageFrontmatter(
 // ---------------------------------------------------------------------------
 
 async function main() {
-  const args = parseArgs();
+  const args = parseBaseArgs({ batch: 20 });
   const engine = createEngine(args.engine);
 
   console.error(`Wiki:   ${WIKI_ROOT}`);
@@ -296,17 +190,12 @@ async function main() {
     `\n🤖 Calling ${args.engine}${args.model ? ` (${args.model})` : ""}...`,
   );
   const startTime = Date.now();
-  const response = await engine.start({
-    task_id: `classify-${Date.now()}`,
-    intent: "ops",
-    workspace_path: WIKI_ROOT,
-    message: prompt,
-    engine: args.engine as any,
+  const response = await dispatchTask(engine, {
+    taskId: `classify-${Date.now()}`,
+    prompt,
+    wikiRoot: WIKI_ROOT,
+    engineName: args.engine,
     model: args.model || undefined,
-    mode: "new",
-    session_id: null,
-    constraints: { timeout_ms: 300_000, allow_network: true },
-    images: [],
   });
   const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
   console.error(`   Done in ${elapsed}s`);
@@ -321,7 +210,7 @@ async function main() {
   // 4. Parse classifications
   let classifications: Classification[];
   try {
-    classifications = parseResponse(response.output);
+    classifications = parseJsonResponse<Classification[]>(response.output);
   } catch (e) {
     console.error(`\n❌ Parse error: ${(e as Error).message}`);
     console.error(
@@ -348,7 +237,6 @@ async function main() {
     const filename = path.basename(oldPath);
     const newPath = `${cls.category}/${filename}`;
 
-    // Read, update frontmatter, write to new location
     try {
       const content = readPage(oldPath);
       const updated = updatePageFrontmatter(content, cls);

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -254,32 +254,45 @@ function expandSource(source: string): string[] {
 // Validation
 // ---------------------------------------------------------------------------
 
-function validateResponse(
-  resp: IngestResponse,
-  sourcePath: string,
-): string | null {
-  // slug <= 60 chars
+/**
+ * Forgiving validation: fix what we can, only reject if truly broken.
+ * Returns null if the response is usable (possibly after auto-fixes).
+ * Returns an error string only if wiki_page_markdown is unparseable.
+ */
+function validateAndFixResponse(resp: IngestResponse): string | null {
+  // Hard reject: no wiki_page_markdown or doesn't contain frontmatter
+  if (
+    !resp.wiki_page_markdown ||
+    !resp.wiki_page_markdown.trimStart().startsWith("---")
+  ) {
+    return "wiki_page_markdown is missing or has no frontmatter (---)";
+  }
+
+  // Auto-fix: slug too long → truncate
   if (resp.slug.length > 60) {
-    return `slug "${resp.slug}" exceeds 60 characters (${resp.slug.length})`;
+    const original = resp.slug;
+    resp.slug = resp.slug.slice(0, 60).replace(/-$/, "");
+    console.error(`   ⚠️  slug truncated: ${original} → ${resp.slug}`);
   }
 
-  // valid category
+  // Auto-fix: invalid category → _uncategorized
   if (!CATEGORIES.includes(resp.category)) {
-    return `invalid category "${resp.category}" (must be one of: ${CATEGORIES.join(", ")})`;
+    console.error(
+      `   ⚠️  invalid category "${resp.category}" → _uncategorized`,
+    );
+    resp.category = "_uncategorized";
   }
 
-  // wiki_page_markdown starts with ---
-  if (!resp.wiki_page_markdown.trimStart().startsWith("---")) {
-    return "wiki_page_markdown does not start with frontmatter (---)";
-  }
-
-  // related_updates paths must exist
+  // Auto-fix: filter out related_updates pointing to non-existent files
   if (resp.related_updates && resp.related_updates.length > 0) {
-    for (const update of resp.related_updates) {
-      if (!wikiFileExists(update.path)) {
-        return `related_updates path "${update.path}" does not exist`;
+    const valid = resp.related_updates.filter((u) => {
+      if (!wikiFileExists(u.path)) {
+        console.error(`   ⚠️  skipping related update: ${u.path} not found`);
+        return false;
       }
-    }
+      return true;
+    });
+    resp.related_updates = valid;
   }
 
   return null;
@@ -526,25 +539,58 @@ async function main() {
         continue;
       }
 
-      // Parse JSON response
+      // Parse JSON response (with same-session retry on failure)
       let result: IngestResponse;
-      try {
-        result = parseJsonResponse<IngestResponse>(response.output);
-      } catch (e) {
-        const msg = `Parse error: ${(e as Error).message}`;
-        console.error(`   \u274c ${msg}`);
-        console.error(`   Output length: ${response.output.length} chars`);
-        console.error(`   First 300: ${response.output.slice(0, 300)}`);
-        console.error(`   Last 200: ${response.output.slice(-200)}`);
-        details.push({ source: sourcePath, status: "failed", error: msg });
-        failed++;
-        continue;
-      }
+      let parseOutput = response.output;
+      let sessionId = response.sessionId;
 
-      // Validate response
-      const validationError = validateResponse(result, sourcePath);
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          result = parseJsonResponse<IngestResponse>(parseOutput);
+          break;
+        } catch (e) {
+          if (attempt === 0 && sessionId) {
+            // Same-session correction: send error back to LLM
+            console.error(
+              `   ⚠️  Parse failed, requesting correction in same session...`,
+            );
+            try {
+              const correction = await engine.send(
+                sessionId,
+                [
+                  "Your previous output could not be parsed as valid JSON.",
+                  `Error: ${(e as Error).message}`,
+                  "Please re-output the SAME content as a single valid JSON object.",
+                  "Make sure all newlines in string values are escaped as \\n.",
+                  "No preamble, no code fences — just the raw JSON object.",
+                ].join(" "),
+                { timeoutMs: 120_000, cwd: WIKI_ROOT },
+              );
+
+              if (!correction.error && correction.output) {
+                parseOutput = correction.output;
+                console.error(
+                  `   🔄 Got correction (${correction.output.length} chars)`,
+                );
+                continue;
+              }
+            } catch {
+              // Correction failed, fall through to error
+            }
+          }
+          const msg = `Parse error: ${(e as Error).message}`;
+          console.error(`   ❌ ${msg}`);
+          console.error(`   Output length: ${parseOutput.length} chars`);
+          details.push({ source: sourcePath, status: "failed", error: msg });
+          failed++;
+        }
+      }
+      if (!result!) continue;
+
+      // Validate response (forgiving — auto-fixes what it can)
+      const validationError = validateAndFixResponse(result);
       if (validationError) {
-        console.error(`   \u274c Validation failed: ${validationError}`);
+        console.error(`   ❌ Validation failed: ${validationError}`);
         details.push({
           source: sourcePath,
           status: "failed",

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -533,9 +533,9 @@ async function main() {
       } catch (e) {
         const msg = `Parse error: ${(e as Error).message}`;
         console.error(`   \u274c ${msg}`);
-        console.error(
-          `   Raw output (first 500 chars): ${response.output.slice(0, 500)}`,
-        );
+        console.error(`   Output length: ${response.output.length} chars`);
+        console.error(`   First 300: ${response.output.slice(0, 300)}`);
+        console.error(`   Last 200: ${response.output.slice(-200)}`);
         details.push({ source: sourcePath, status: "failed", error: msg });
         failed++;
         continue;

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -46,21 +46,21 @@ interface IngestArgs {
   model: string;
   batch: number;
   dryRun: boolean;
-  source: string | null;
+  sources: string[];
 }
 
 function parseIngestArgs(): IngestArgs {
   const base = parseBaseArgs({ batch: 10 });
-  let source: string | null = null;
+  const sources: string[] = [];
 
   const args = process.argv.slice(2);
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--source" || args[i] === "-s") {
-      source = args[++i];
+      sources.push(args[++i]);
     }
   }
 
-  return { ...base, source };
+  return { ...base, sources };
 }
 
 // ---------------------------------------------------------------------------
@@ -198,7 +198,7 @@ function scanRawSources(batch: number): string[] {
   let allRaw: string[];
   try {
     allRaw = execSync(
-      `find "${rawDir}" -type f \\( -name "*.md" -o -name "*.json" \\)`,
+      `find "${rawDir}" -maxdepth 2 -type f \\( -name "*.md" -o -name "*.json" \\)`,
       { encoding: "utf-8", timeout: 10_000 },
     )
       .trim()
@@ -411,10 +411,10 @@ async function main() {
   console.error("\n\ud83d\udd0d Building source list...");
   let sources: string[];
 
-  if (args.source) {
-    sources = expandSource(args.source);
+  if (args.sources.length > 0) {
+    sources = args.sources.flatMap((s) => expandSource(s));
     if (sources.length === 0) {
-      console.error(`   \u274c No files matched --source "${args.source}"`);
+      console.error(`   \u274c No files matched --source arguments`);
       console.log(
         JSON.stringify({ created: 0, skipped: 0, failed: 0, details: [] }),
       );

--- a/src/ingest.ts
+++ b/src/ingest.ts
@@ -1,0 +1,667 @@
+#!/usr/bin/env tsx
+/**
+ * Wiki Ingest Agent
+ *
+ * Batch-ingest raw source files into wiki pages via LLM.
+ * Each source gets a full wiki page (frontmatter + structured body + cross-references),
+ * with index.md and log.md updated after each page.
+ *
+ * Usage:
+ *   npm run ingest                                    # auto-scan raw/
+ *   npm run ingest -- --source "raw/articles/foo.md"  # explicit source
+ *   npm run ingest -- --batch 5 --dry-run             # preview 5 sources
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import path from "node:path";
+import {
+  WIKI_ROOT,
+  createEngine,
+  parseBaseArgs,
+  parseJsonResponse,
+  loadPrompt,
+  dispatchTask,
+} from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Categories (same as classify.ts — concepts excluded per spec)
+// ---------------------------------------------------------------------------
+
+const CATEGORIES = [
+  "architecture",
+  "training",
+  "infra",
+  "tools",
+  "product",
+  "ops",
+];
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing (extends BaseArgs with --source)
+// ---------------------------------------------------------------------------
+
+interface IngestArgs {
+  engine: string;
+  model: string;
+  batch: number;
+  dryRun: boolean;
+  source: string | null;
+}
+
+function parseIngestArgs(): IngestArgs {
+  const base = parseBaseArgs({ batch: 10 });
+  let source: string | null = null;
+
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--source" || args[i] === "-s") {
+      source = args[++i];
+    }
+  }
+
+  return { ...base, source };
+}
+
+// ---------------------------------------------------------------------------
+// Engine response schema
+// ---------------------------------------------------------------------------
+
+interface IngestResponse {
+  slug: string;
+  category: string;
+  wiki_page_markdown: string;
+  index_entry: string;
+  log_entry: string;
+  related_updates: Array<{
+    path: string;
+    add_related: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Stdout detail records
+// ---------------------------------------------------------------------------
+
+interface IngestDetail {
+  source: string;
+  status: "created" | "skipped" | "failed";
+  page?: string;
+  reason?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Wiki file helpers
+// ---------------------------------------------------------------------------
+
+function readWikiFile(relPath: string): string {
+  const absPath = path.join(WIKI_ROOT, "wiki", relPath);
+  return readFileSync(absPath, "utf-8");
+}
+
+function writeWikiFile(relPath: string, content: string): void {
+  const absPath = path.join(WIKI_ROOT, "wiki", relPath);
+  mkdirSync(path.dirname(absPath), { recursive: true });
+  writeFileSync(absPath, content, "utf-8");
+}
+
+function wikiFileExists(relPath: string): boolean {
+  return existsSync(path.join(WIKI_ROOT, "wiki", relPath));
+}
+
+function readRawFile(relPath: string): string {
+  const absPath = path.join(WIKI_ROOT, relPath);
+  return readFileSync(absPath, "utf-8");
+}
+
+function readConventions(): string {
+  const claudeMdPath = path.join(WIKI_ROOT, "CLAUDE.md");
+  return readFileSync(claudeMdPath, "utf-8");
+}
+
+function readIndex(): string {
+  return readWikiFile("index.md");
+}
+
+// ---------------------------------------------------------------------------
+// Source scanning: find raw sources not yet ingested
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all `sources:` values referenced across every wiki page.
+ * Scans all .md files under wiki/ category directories.
+ */
+function collectIngestedSources(): Set<string> {
+  const ingested = new Set<string>();
+  const wikiDir = path.join(WIKI_ROOT, "wiki");
+
+  for (const category of [...CATEGORIES, "concepts", "_uncategorized"]) {
+    const catDir = path.join(wikiDir, category);
+    if (!existsSync(catDir)) continue;
+
+    let files: string[];
+    try {
+      files = execSync(`find "${catDir}" -name "*.md" -type f`, {
+        encoding: "utf-8",
+        timeout: 10_000,
+      })
+        .trim()
+        .split("\n")
+        .filter(Boolean);
+    } catch {
+      continue;
+    }
+
+    for (const file of files) {
+      try {
+        const content = readFileSync(file, "utf-8");
+        // Extract sources: from frontmatter
+        const fmMatch = content.match(/^---\n([\s\S]*?)\n---/);
+        if (!fmMatch) continue;
+        const fm = fmMatch[1];
+        // Match sources: list items (YAML list under sources:)
+        const sourcesMatch = fm.match(/^sources:\s*\n((?:\s+-\s+.*\n?)*)/m);
+        if (sourcesMatch) {
+          const lines = sourcesMatch[1].split("\n");
+          for (const line of lines) {
+            const m = line.match(/^\s+-\s+(.+)/);
+            if (m) ingested.add(m[1].trim());
+          }
+        }
+        // Also match inline sources: [item] or sources: - item on same line
+        const inlineMatch = fm.match(/^sources:\s*\[([^\]]*)\]/m);
+        if (inlineMatch && inlineMatch[1].trim()) {
+          for (const s of inlineMatch[1].split(",")) {
+            ingested.add(s.trim());
+          }
+        }
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+
+  return ingested;
+}
+
+/**
+ * Scan raw/**\/*.{md,json} and return paths not already ingested.
+ */
+function scanRawSources(batch: number): string[] {
+  const rawDir = path.join(WIKI_ROOT, "raw");
+  if (!existsSync(rawDir)) {
+    console.error("   No raw/ directory found. Nothing to ingest.");
+    return [];
+  }
+
+  let allRaw: string[];
+  try {
+    allRaw = execSync(
+      `find "${rawDir}" -type f \\( -name "*.md" -o -name "*.json" \\)`,
+      { encoding: "utf-8", timeout: 10_000 },
+    )
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((absPath) => path.relative(WIKI_ROOT, absPath));
+  } catch {
+    return [];
+  }
+
+  const ingested = collectIngestedSources();
+  const unprocessed = allRaw.filter((p) => !ingested.has(p));
+
+  console.error(
+    `   Found ${allRaw.length} raw files, ${ingested.size} already ingested, ${unprocessed.length} remaining`,
+  );
+
+  return unprocessed.slice(0, batch);
+}
+
+/**
+ * Expand an explicit --source argument (may be a glob or a single path).
+ */
+function expandSource(source: string): string[] {
+  // Try glob expansion via shell
+  try {
+    const expanded = execSync(
+      `cd "${WIKI_ROOT}" && ls -1 ${source} 2>/dev/null`,
+      { encoding: "utf-8", timeout: 5_000 },
+    )
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    if (expanded.length > 0) return expanded;
+  } catch {
+    // fall through
+  }
+
+  // If it's a single path that exists
+  if (existsSync(path.join(WIKI_ROOT, source))) {
+    return [source];
+  }
+
+  // Absolute path check
+  if (existsSync(source)) {
+    return [path.relative(WIKI_ROOT, source)];
+  }
+
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function validateResponse(
+  resp: IngestResponse,
+  sourcePath: string,
+): string | null {
+  // slug <= 60 chars
+  if (resp.slug.length > 60) {
+    return `slug "${resp.slug}" exceeds 60 characters (${resp.slug.length})`;
+  }
+
+  // valid category
+  if (!CATEGORIES.includes(resp.category)) {
+    return `invalid category "${resp.category}" (must be one of: ${CATEGORIES.join(", ")})`;
+  }
+
+  // wiki_page_markdown starts with ---
+  if (!resp.wiki_page_markdown.trimStart().startsWith("---")) {
+    return "wiki_page_markdown does not start with frontmatter (---)";
+  }
+
+  // related_updates paths must exist
+  if (resp.related_updates && resp.related_updates.length > 0) {
+    for (const update of resp.related_updates) {
+      if (!wikiFileExists(update.path)) {
+        return `related_updates path "${update.path}" does not exist`;
+      }
+    }
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Apply related updates to existing pages
+// ---------------------------------------------------------------------------
+
+function applyRelatedUpdates(updates: IngestResponse["related_updates"]): void {
+  for (const update of updates) {
+    if (!wikiFileExists(update.path)) {
+      console.error(
+        `   \u26a0\ufe0f  Skipping related update: ${update.path} not found`,
+      );
+      continue;
+    }
+
+    const content = readWikiFile(update.path);
+    const relatedEntry = update.add_related;
+
+    // Check if already referenced
+    if (content.includes(relatedEntry)) {
+      console.error(
+        `   \u2022 ${update.path} already references ${relatedEntry}`,
+      );
+      continue;
+    }
+
+    // Add to related: frontmatter list
+    const fmMatch = content.match(
+      /^(---\n[\s\S]*?)(related:\s*\n(?:\s+-\s+.*\n?)*)([\s\S]*)/,
+    );
+    if (fmMatch) {
+      const updated =
+        fmMatch[1] +
+        fmMatch[2].trimEnd() +
+        `\n  - ${relatedEntry}\n` +
+        fmMatch[3];
+      writeWikiFile(update.path, updated);
+      console.error(
+        `   \u2714 Added ${relatedEntry} to ${update.path} related: list`,
+      );
+    } else {
+      // Try inserting related: before closing ---
+      const fmEndMatch = content.match(/^(---\n[\s\S]*?)\n(---)/);
+      if (fmEndMatch) {
+        const updated =
+          fmEndMatch[1] +
+          `\nrelated:\n  - ${relatedEntry}\n` +
+          fmEndMatch[2] +
+          content.slice(fmEndMatch[0].length);
+        writeWikiFile(update.path, updated);
+        console.error(
+          `   \u2714 Created related: in ${update.path} with ${relatedEntry}`,
+        );
+      } else {
+        console.error(
+          `   \u26a0\ufe0f  Could not update related: in ${update.path} (no frontmatter)`,
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Append to index.md and log.md
+// ---------------------------------------------------------------------------
+
+function appendToIndex(indexEntry: string): void {
+  const indexPath = path.join(WIKI_ROOT, "wiki", "index.md");
+  const content = readFileSync(indexPath, "utf-8");
+  writeFileSync(
+    indexPath,
+    content.trimEnd() + "\n" + indexEntry + "\n",
+    "utf-8",
+  );
+}
+
+function appendToLog(logEntry: string): void {
+  const logPath = path.join(WIKI_ROOT, "wiki", "log.md");
+  const date = new Date().toISOString().slice(0, 10);
+  const entry = `[${date}] ${logEntry}`;
+
+  if (existsSync(logPath)) {
+    const content = readFileSync(logPath, "utf-8");
+    writeFileSync(logPath, content.trimEnd() + "\n" + entry + "\n", "utf-8");
+  } else {
+    writeFileSync(logPath, `# Wiki Log\n\n${entry}\n`, "utf-8");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseIngestArgs();
+  const engine = createEngine(args.engine);
+
+  console.error(`\ud83d\udcda Wiki Ingest Agent`);
+  console.error(`Wiki:   ${WIKI_ROOT}`);
+  console.error(
+    `Engine: ${args.engine}${args.model ? ` (${args.model})` : ""}`,
+  );
+  console.error(`Batch:  ${args.batch}`);
+  if (args.dryRun) console.error(`Mode:   DRY RUN`);
+  console.error("");
+
+  // 1. Load conventions
+  console.error("\ud83d\udcc4 Loading wiki conventions...");
+  const conventions = readConventions();
+  console.error(`   CLAUDE.md: ${conventions.length} chars`);
+
+  // 2. Build source list
+  console.error("\n\ud83d\udd0d Building source list...");
+  let sources: string[];
+
+  if (args.source) {
+    sources = expandSource(args.source);
+    if (sources.length === 0) {
+      console.error(`   \u274c No files matched --source "${args.source}"`);
+      console.log(
+        JSON.stringify({ created: 0, skipped: 0, failed: 0, details: [] }),
+      );
+      process.exit(0);
+    }
+    sources = sources.slice(0, args.batch);
+    console.error(`   Using explicit sources: ${sources.length} file(s)`);
+  } else {
+    sources = scanRawSources(args.batch);
+    if (sources.length === 0) {
+      console.error("   \u2705 All raw sources already ingested. Done.");
+      console.log(
+        JSON.stringify({ created: 0, skipped: 0, failed: 0, details: [] }),
+      );
+      process.exit(0);
+    }
+  }
+
+  console.error("");
+  for (const s of sources) {
+    console.error(`   \u2022 ${s}`);
+  }
+  console.error("");
+
+  // Dry run: show what would be processed
+  if (args.dryRun) {
+    const details: IngestDetail[] = sources.map((s) => ({
+      source: s,
+      status: "skipped" as const,
+      reason: "dry-run",
+    }));
+    console.error(`\u2705 DRY RUN: Would process ${sources.length} source(s).`);
+    console.error("");
+
+    // Show a prompt preview for the first source
+    if (sources.length > 0) {
+      const index = readIndex();
+      const sourceContent = readRawFile(sources[0]);
+      const prompt = loadPrompt("ingest", {
+        conventions,
+        index,
+        source_path: sources[0],
+        source_content: sourceContent,
+      });
+      console.error("--- Prompt preview (first source, truncated) ---");
+      console.error(prompt.slice(0, 2000) + "...");
+      console.error("");
+    }
+
+    console.log(
+      JSON.stringify({
+        created: 0,
+        skipped: sources.length,
+        failed: 0,
+        details,
+      }),
+    );
+    process.exit(0);
+  }
+
+  // 3. Sequential processing
+  const details: IngestDetail[] = [];
+  let created = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (let i = 0; i < sources.length; i++) {
+    const sourcePath = sources[i];
+    console.error(
+      `\n\ud83d\udce6 [${i + 1}/${sources.length}] Processing: ${sourcePath}`,
+    );
+
+    try {
+      // Re-read index.md fresh (may have been updated by prior iteration)
+      const index = readIndex();
+
+      // Read raw source content
+      let sourceContent: string;
+      try {
+        sourceContent = readRawFile(sourcePath);
+      } catch (e) {
+        const msg = `Cannot read source: ${(e as Error).message}`;
+        console.error(`   \u274c ${msg}`);
+        details.push({ source: sourcePath, status: "failed", error: msg });
+        failed++;
+        continue;
+      }
+      console.error(`   Source: ${sourceContent.length} chars`);
+
+      // Build prompt
+      const prompt = loadPrompt("ingest", {
+        conventions,
+        index,
+        source_path: sourcePath,
+        source_content: sourceContent,
+      });
+      console.error(`   Prompt: ${prompt.length} chars`);
+
+      // Dispatch via codebridge
+      console.error(
+        `   \ud83e\udd16 Calling ${args.engine}${args.model ? ` (${args.model})` : ""}...`,
+      );
+      const startTime = Date.now();
+      const response = await dispatchTask(engine, {
+        taskId: `ingest-${Date.now()}`,
+        prompt,
+        wikiRoot: WIKI_ROOT,
+        engineName: args.engine,
+        model: args.model || undefined,
+      });
+      const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+      console.error(`   Done in ${elapsed}s`);
+
+      if (response.error) {
+        const msg = `LLM error: ${response.error.message}`;
+        console.error(`   \u274c ${msg}`);
+        if (response.stderr) {
+          console.error(`   stderr: ${response.stderr.slice(0, 500)}`);
+        }
+        details.push({ source: sourcePath, status: "failed", error: msg });
+        failed++;
+        continue;
+      }
+
+      // Parse JSON response
+      let result: IngestResponse;
+      try {
+        result = parseJsonResponse<IngestResponse>(response.output);
+      } catch (e) {
+        const msg = `Parse error: ${(e as Error).message}`;
+        console.error(`   \u274c ${msg}`);
+        console.error(
+          `   Raw output (first 500 chars): ${response.output.slice(0, 500)}`,
+        );
+        details.push({ source: sourcePath, status: "failed", error: msg });
+        failed++;
+        continue;
+      }
+
+      // Validate response
+      const validationError = validateResponse(result, sourcePath);
+      if (validationError) {
+        console.error(`   \u274c Validation failed: ${validationError}`);
+        details.push({
+          source: sourcePath,
+          status: "failed",
+          error: `Validation: ${validationError}`,
+        });
+        failed++;
+        continue;
+      }
+
+      // Write wiki page
+      const pagePath = `${result.category}/${result.slug}.md`;
+      console.error(`   \ud83d\udcdd Writing: wiki/${pagePath}`);
+      try {
+        writeWikiFile(pagePath, result.wiki_page_markdown);
+      } catch (e) {
+        // File write failure: abort entire run
+        console.error(
+          `\n\u274c FATAL: File write failed: ${(e as Error).message}`,
+        );
+        console.error("   Aborting run (filesystem error is not recoverable).");
+        details.push({
+          source: sourcePath,
+          status: "failed",
+          error: `File write failed: ${(e as Error).message}`,
+        });
+        failed++;
+        console.log(JSON.stringify({ created, skipped, failed, details }));
+        process.exit(1);
+      }
+
+      // Apply related updates
+      if (result.related_updates && result.related_updates.length > 0) {
+        console.error(
+          `   \ud83d\udd17 Applying ${result.related_updates.length} related update(s)...`,
+        );
+        try {
+          applyRelatedUpdates(result.related_updates);
+        } catch (e) {
+          // Related update write failure: abort
+          console.error(
+            `\n\u274c FATAL: Related update write failed: ${(e as Error).message}`,
+          );
+          console.error(
+            "   Aborting run (filesystem error is not recoverable).",
+          );
+          details.push({
+            source: sourcePath,
+            status: "failed",
+            error: `Related update write failed: ${(e as Error).message}`,
+          });
+          failed++;
+          console.log(JSON.stringify({ created, skipped, failed, details }));
+          process.exit(1);
+        }
+      }
+
+      // Append to index.md
+      console.error(`   \ud83d\udcc7 Updating index.md`);
+      try {
+        appendToIndex(result.index_entry);
+      } catch (e) {
+        console.error(
+          `\n\u274c FATAL: Index write failed: ${(e as Error).message}`,
+        );
+        details.push({
+          source: sourcePath,
+          status: "failed",
+          error: `Index write failed: ${(e as Error).message}`,
+        });
+        failed++;
+        console.log(JSON.stringify({ created, skipped, failed, details }));
+        process.exit(1);
+      }
+
+      // Append to log.md
+      console.error(`   \ud83d\udcdd Updating log.md`);
+      try {
+        appendToLog(result.log_entry);
+      } catch (e) {
+        console.error(
+          `\n\u274c FATAL: Log write failed: ${(e as Error).message}`,
+        );
+        details.push({
+          source: sourcePath,
+          status: "failed",
+          error: `Log write failed: ${(e as Error).message}`,
+        });
+        failed++;
+        console.log(JSON.stringify({ created, skipped, failed, details }));
+        process.exit(1);
+      }
+
+      // Success
+      console.error(`   \u2705 Created: ${pagePath}`);
+      details.push({
+        source: sourcePath,
+        status: "created",
+        page: pagePath,
+      });
+      created++;
+    } catch (e) {
+      // Catch-all for unexpected errors in a single source
+      const msg = `Unexpected error: ${(e as Error).message}`;
+      console.error(`   \u274c ${msg}`);
+      details.push({ source: sourcePath, status: "failed", error: msg });
+      failed++;
+    }
+  }
+
+  // 4. Output summary
+  console.error(
+    `\n\ud83d\udcca Summary: ${created} created, ${skipped} skipped, ${failed} failed`,
+  );
+  console.log(JSON.stringify({ created, skipped, failed, details }));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -73,18 +73,23 @@ function parseLintArgs(): LintArgs {
 // Types
 // ---------------------------------------------------------------------------
 
+interface LintFinding {
+  path: string;
+  detail: string;
+}
+
 interface FreshnessReport {
   fresh: number;
   suspect: number;
   stale: number;
-  stale_pages: string[];
+  stale_pages: LintFinding[];
 }
 
 interface LintReport {
-  todo_pages: string[];
-  broken_related: { page: string; broken_link: string }[];
-  orphan_pages: string[];
-  missing_concepts: { slug: string; references: string[] }[];
+  todo_pages: LintFinding[];
+  broken_related: LintFinding[];
+  orphan_pages: LintFinding[];
+  missing_concepts: LintFinding[];
   freshness: FreshnessReport;
 }
 
@@ -143,6 +148,43 @@ function runLint(category: string): LintReport {
   const categoryArg = category ? ` --category ${category}` : "";
   const raw = lw(`lint --format json${categoryArg}`);
   return JSON.parse(raw) as LintReport;
+}
+
+// ---------------------------------------------------------------------------
+// Wikilink scanner — find pages that reference [[slug]]
+// ---------------------------------------------------------------------------
+
+function findReferencingPages(slug: string): string[] {
+  const results: string[] = [];
+  const categories = [
+    "architecture",
+    "training",
+    "infra",
+    "tools",
+    "product",
+    "ops",
+    "concepts",
+  ];
+
+  for (const cat of categories) {
+    const catDir = path.join(WIKI_DIR, cat);
+    if (!existsSync(catDir)) continue;
+    let files: string[];
+    try {
+      files = readdirSync(catDir).filter((f) => f.endsWith(".md"));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      const content = readFileSync(path.join(catDir, file), "utf-8");
+      // Match [[slug]] or [[slug|display text]]
+      if (content.includes(`[[${slug}]]`) || content.includes(`[[${slug}|`)) {
+        results.push(`${cat}/${file}`);
+      }
+    }
+  }
+
+  return results;
 }
 
 // ---------------------------------------------------------------------------
@@ -206,7 +248,18 @@ function computeSimilarity(a: string, b: string): number {
 function fixBrokenRelated(findings: LintReport["broken_related"]): number {
   let fixed = 0;
 
-  for (const { page, broken_link } of findings) {
+  for (const finding of findings) {
+    const page = finding.path;
+    // Extract broken link target from detail: "related entry not found: ops/bar.md"
+    const linkMatch = finding.detail.match(/related entry not found: (.+)/);
+    if (!linkMatch) {
+      console.error(
+        `   skipped ${page} — could not parse detail: ${finding.detail}`,
+      );
+      continue;
+    }
+    const broken_link = linkMatch[1];
+
     const absPath = path.join(WIKI_DIR, page);
     if (!existsSync(absPath)) {
       console.error(`   skipped ${page} — file not found`);
@@ -217,11 +270,9 @@ function fixBrokenRelated(findings: LintReport["broken_related"]): number {
     const match = findClosestMatch(broken_link);
 
     if (match) {
-      // Replace the broken link with the closest match
       content = content.replaceAll(broken_link, match);
       console.error(`   fixed ${page}: ${broken_link} -> ${match}`);
     } else {
-      // Remove the broken related entry from frontmatter
       const lines = content.split("\n");
       const filtered = lines.filter((line) => !line.includes(broken_link));
       content = filtered.join("\n");
@@ -239,7 +290,7 @@ function fixBrokenRelated(findings: LintReport["broken_related"]): number {
 // Auto-fix: orphan_pages
 // ---------------------------------------------------------------------------
 
-function fixOrphanPages(orphans: string[]): number {
+function fixOrphanPages(orphans: LintFinding[]): number {
   if (orphans.length === 0) return 0;
 
   const indexPath = path.join(WIKI_DIR, "index.md");
@@ -257,7 +308,8 @@ function fixOrphanPages(orphans: string[]): number {
     concepts: "## Concepts",
   };
 
-  for (const orphan of orphans) {
+  for (const finding of orphans) {
+    const orphan = finding.path;
     // Extract category from path (e.g., "ops/foo.md" -> "ops")
     const category = orphan.split("/")[0];
     const heading = categoryHeadings[category];
@@ -318,16 +370,18 @@ async function proposeMissingConcepts(
   const conventions = readConventions();
   const engine = createEngine(args.engine);
 
-  // Only process concepts with 3+ references (spec requirement)
-  const eligible = concepts.filter((c) => c.references.length >= 3);
+  for (const finding of concepts) {
+    // Extract slug from path: "concepts/foo.md" -> "foo"
+    const slug = path.basename(finding.path, ".md");
 
-  for (const concept of eligible) {
-    console.error(
-      `   generating concept: ${concept.slug} (${concept.references.length} refs)`,
-    );
+    // Scan wiki for pages that reference [[slug]] to find the actual referencing pages
+    const references = findReferencingPages(slug);
+    if (references.length < 3) continue; // Safety check
+
+    console.error(`   generating concept: ${slug} (${references.length} refs)`);
 
     // Read referencing pages, truncated to 300 chars each
-    const referencingPages = concept.references
+    const referencingPages = references
       .map((ref) => {
         try {
           const content = readWikiFile(ref);
@@ -341,9 +395,8 @@ async function proposeMissingConcepts(
     const prompt = loadPrompt("lint-fix", {
       mode: "concept",
       conventions,
-      concept_slug: concept.slug,
+      concept_slug: slug,
       referencing_pages: referencingPages,
-      // Mode B placeholders — empty when in concept mode
       current_page: "",
       raw_source: "",
     });
@@ -357,7 +410,7 @@ async function proposeMissingConcepts(
 
     try {
       const response = await dispatchTask(engine, {
-        taskId: `lint-concept-${concept.slug}-${Date.now()}`,
+        taskId: `lint-concept-${slug}-${Date.now()}`,
         prompt,
         wikiRoot: WIKI_ROOT,
         engineName: args.engine,
@@ -365,9 +418,7 @@ async function proposeMissingConcepts(
       });
 
       if (response.error) {
-        console.error(
-          `   error for ${concept.slug}: ${response.error.message}`,
-        );
+        console.error(`   error for ${slug}: ${response.error.message}`);
         continue;
       }
 
@@ -380,15 +431,15 @@ async function proposeMissingConcepts(
 
       proposals.push({
         type: "create_concept",
-        slug: parsed.slug || concept.slug,
+        slug: parsed.slug || slug,
         content: parsed.wiki_page_markdown,
         index_entry: parsed.index_entry,
         related_updates: parsed.related_updates || [],
       });
 
-      console.error(`   proposal ready: ${concept.slug}`);
+      console.error(`   proposal ready: ${slug}`);
     } catch (e) {
-      console.error(`   failed for ${concept.slug}: ${(e as Error).message}`);
+      console.error(`   failed for ${slug}: ${(e as Error).message}`);
     }
   }
 
@@ -400,14 +451,15 @@ async function proposeMissingConcepts(
 // ---------------------------------------------------------------------------
 
 async function proposeTodoRewrites(
-  todoPages: string[],
+  todoPages: LintFinding[],
   args: LintArgs,
 ): Promise<RewriteProposal[]> {
   const proposals: RewriteProposal[] = [];
   const conventions = readConventions();
   const engine = createEngine(args.engine);
 
-  for (const pagePath of todoPages) {
+  for (const finding of todoPages) {
+    const pagePath = finding.path;
     console.error(`   generating rewrite: ${pagePath}`);
 
     let currentPage: string;
@@ -761,7 +813,7 @@ async function main() {
   if (report.freshness.stale_pages.length > 0) {
     proposals.push({
       type: "stale_warning",
-      paths: report.freshness.stale_pages,
+      paths: report.freshness.stale_pages.map((f) => f.path),
     });
   }
 
@@ -793,7 +845,7 @@ async function main() {
           }
           return p;
         }),
-      stale_warnings: report.freshness.stale_pages,
+      stale_warnings: report.freshness.stale_pages.map((f) => f.path),
     };
     console.log(JSON.stringify(output, null, 2));
     return;
@@ -835,7 +887,7 @@ async function main() {
       concept_pages: applied.concept_pages,
       rewrites: applied.rewrites,
     },
-    stale_warnings: report.freshness.stale_pages,
+    stale_warnings: report.freshness.stale_pages.map((f) => f.path),
     lint_after: lintAfter,
   };
   console.log(JSON.stringify(output, null, 2));

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,0 +1,847 @@
+#!/usr/bin/env tsx
+/**
+ * Wiki Lint Agent
+ *
+ * Runs wiki health checks via `lw lint`, then fixes issues.
+ * Simple fixes are automatic; complex fixes (requiring LLM content generation)
+ * produce proposals that need `--apply` to execute.
+ *
+ * Three modes:
+ *   Report (default): run `lw lint --format json`, output findings, exit
+ *   Fix (--fix):      auto-fix simple issues + generate LLM proposals
+ *   Apply (--fix --apply): auto-fix + execute LLM proposals, then re-lint
+ *
+ * Usage:
+ *   npm run lint                              # report only
+ *   npm run lint -- --fix                     # auto-fix + proposals
+ *   npm run lint -- --fix --apply             # auto-fix + apply proposals
+ *   npm run lint -- --fix --category ops      # scope to one category
+ */
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+import {
+  WIKI_ROOT,
+  lw,
+  createEngine,
+  parseBaseArgs,
+  parseJsonResponse,
+  loadPrompt,
+  dispatchTask,
+} from "./shared.js";
+import type { BaseArgs } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// CLI args (extends BaseArgs)
+// ---------------------------------------------------------------------------
+
+interface LintArgs extends BaseArgs {
+  fix: boolean;
+  apply: boolean;
+  category: string;
+}
+
+function parseLintArgs(): LintArgs {
+  const base = parseBaseArgs({ batch: 20 });
+  const argv = process.argv.slice(2);
+  let fix = false;
+  let apply = false;
+  let category = "";
+
+  for (let i = 0; i < argv.length; i++) {
+    switch (argv[i]) {
+      case "--fix":
+        fix = true;
+        break;
+      case "--apply":
+        apply = true;
+        break;
+      case "--category":
+      case "-c":
+        category = argv[++i];
+        break;
+    }
+  }
+
+  // --apply implies --fix
+  if (apply) fix = true;
+
+  return { ...base, fix, apply, category };
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface FreshnessReport {
+  fresh: number;
+  suspect: number;
+  stale: number;
+  stale_pages: string[];
+}
+
+interface LintReport {
+  todo_pages: string[];
+  broken_related: { page: string; broken_link: string }[];
+  orphan_pages: string[];
+  missing_concepts: { slug: string; references: string[] }[];
+  freshness: FreshnessReport;
+}
+
+interface ConceptProposal {
+  type: "create_concept";
+  slug: string;
+  content: string;
+  index_entry: string;
+  related_updates: { path: string; add_related: string }[];
+}
+
+interface RewriteProposal {
+  type: "rewrite_page";
+  path: string;
+  content: string;
+  index_entry: string;
+}
+
+interface StaleWarning {
+  type: "stale_warning";
+  paths: string[];
+}
+
+type Proposal = ConceptProposal | RewriteProposal | StaleWarning;
+
+// ---------------------------------------------------------------------------
+// Wiki I/O helpers
+// ---------------------------------------------------------------------------
+
+const WIKI_DIR = path.join(WIKI_ROOT, "wiki");
+
+function readWikiFile(relPath: string): string {
+  const absPath = path.join(WIKI_DIR, relPath);
+  return readFileSync(absPath, "utf-8");
+}
+
+function writeWikiFile(relPath: string, content: string): void {
+  const absPath = path.join(WIKI_DIR, relPath);
+  writeFileSync(absPath, content, "utf-8");
+}
+
+function wikiFileExists(relPath: string): boolean {
+  return existsSync(path.join(WIKI_DIR, relPath));
+}
+
+function readConventions(): string {
+  const claudeMdPath = path.join(WIKI_ROOT, "CLAUDE.md");
+  return readFileSync(claudeMdPath, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// lw lint wrapper
+// ---------------------------------------------------------------------------
+
+function runLint(category: string): LintReport {
+  const categoryArg = category ? ` --category ${category}` : "";
+  const raw = lw(`lint --format json${categoryArg}`);
+  return JSON.parse(raw) as LintReport;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-fix: broken_related
+// ---------------------------------------------------------------------------
+
+function findClosestMatch(brokenLink: string): string | null {
+  // Extract the category and filename parts
+  const parts = brokenLink.split("/");
+  if (parts.length < 2) return null;
+
+  const category = parts[0];
+  const categoryDir = path.join(WIKI_DIR, category);
+
+  if (!existsSync(categoryDir)) return null;
+
+  let files: string[];
+  try {
+    files = readdirSync(categoryDir).filter((f) => f.endsWith(".md"));
+  } catch {
+    return null;
+  }
+
+  const brokenSlug = path.basename(brokenLink, ".md").toLowerCase();
+
+  // Try to find a file whose slug shares significant overlap
+  let bestMatch: string | null = null;
+  let bestScore = 0;
+
+  for (const file of files) {
+    const fileSlug = path.basename(file, ".md").toLowerCase();
+    const score = computeSimilarity(brokenSlug, fileSlug);
+    if (score > bestScore && score > 0.5) {
+      bestScore = score;
+      bestMatch = `${category}/${file}`;
+    }
+  }
+
+  return bestMatch;
+}
+
+/** Simple bigram similarity (Dice coefficient) */
+function computeSimilarity(a: string, b: string): number {
+  if (a === b) return 1;
+  if (a.length < 2 || b.length < 2) return 0;
+
+  const bigramsA = new Set<string>();
+  for (let i = 0; i < a.length - 1; i++) bigramsA.add(a.slice(i, i + 2));
+
+  let intersection = 0;
+  const bigramsB = new Set<string>();
+  for (let i = 0; i < b.length - 1; i++) {
+    const bigram = b.slice(i, i + 2);
+    bigramsB.add(bigram);
+    if (bigramsA.has(bigram)) intersection++;
+  }
+
+  return (2 * intersection) / (bigramsA.size + bigramsB.size);
+}
+
+function fixBrokenRelated(findings: LintReport["broken_related"]): number {
+  let fixed = 0;
+
+  for (const { page, broken_link } of findings) {
+    const absPath = path.join(WIKI_DIR, page);
+    if (!existsSync(absPath)) {
+      console.error(`   skipped ${page} — file not found`);
+      continue;
+    }
+
+    let content = readFileSync(absPath, "utf-8");
+    const match = findClosestMatch(broken_link);
+
+    if (match) {
+      // Replace the broken link with the closest match
+      content = content.replaceAll(broken_link, match);
+      console.error(`   fixed ${page}: ${broken_link} -> ${match}`);
+    } else {
+      // Remove the broken related entry from frontmatter
+      const lines = content.split("\n");
+      const filtered = lines.filter((line) => !line.includes(broken_link));
+      content = filtered.join("\n");
+      console.error(`   removed ${page}: ${broken_link} (no match found)`);
+    }
+
+    writeFileSync(absPath, content, "utf-8");
+    fixed++;
+  }
+
+  return fixed;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-fix: orphan_pages
+// ---------------------------------------------------------------------------
+
+function fixOrphanPages(orphans: string[]): number {
+  if (orphans.length === 0) return 0;
+
+  const indexPath = path.join(WIKI_DIR, "index.md");
+  let indexContent = readFileSync(indexPath, "utf-8");
+  let fixed = 0;
+
+  // Category heading map (matches the wiki index.md headings)
+  const categoryHeadings: Record<string, string> = {
+    ops: "## Ops",
+    architecture: "## Architecture",
+    training: "## Training",
+    infra: "## Infra",
+    tools: "## Tools",
+    product: "## Product",
+    concepts: "## Concepts",
+  };
+
+  for (const orphan of orphans) {
+    // Extract category from path (e.g., "ops/foo.md" -> "ops")
+    const category = orphan.split("/")[0];
+    const heading = categoryHeadings[category];
+
+    if (!heading) {
+      console.error(
+        `   skipped orphan ${orphan} — unknown category "${category}"`,
+      );
+      continue;
+    }
+
+    // Read the page to get its title for the index entry
+    let title = path.basename(orphan, ".md");
+    try {
+      const pageContent = readWikiFile(orphan);
+      const titleMatch = pageContent.match(/^title:\s*"?([^"\n]+)"?\s*$/m);
+      if (titleMatch) title = titleMatch[1].trim();
+    } catch {
+      // Use filename as title fallback
+    }
+
+    const entry = `- [${title}](${orphan}) — (auto-added by lint)`;
+
+    // Find the heading in index.md and append after the last entry in that section
+    const headingIdx = indexContent.indexOf(heading);
+    if (headingIdx === -1) {
+      // Heading doesn't exist yet — append it at the end
+      indexContent += `\n\n${heading}\n\n${entry}\n`;
+    } else {
+      // Find the next heading (## ) or end of file
+      const afterHeading = indexContent.indexOf("\n", headingIdx);
+      const nextHeading = indexContent.indexOf("\n## ", afterHeading + 1);
+      const insertPos = nextHeading === -1 ? indexContent.length : nextHeading;
+
+      // Insert the entry before the next heading
+      const before = indexContent.slice(0, insertPos).trimEnd();
+      const after = indexContent.slice(insertPos);
+      indexContent = before + "\n" + entry + "\n" + after;
+    }
+
+    console.error(`   added orphan to index: ${orphan}`);
+    fixed++;
+  }
+
+  writeFileSync(indexPath, indexContent, "utf-8");
+  return fixed;
+}
+
+// ---------------------------------------------------------------------------
+// LLM proposal: missing_concepts
+// ---------------------------------------------------------------------------
+
+async function proposeMissingConcepts(
+  concepts: LintReport["missing_concepts"],
+  args: LintArgs,
+): Promise<ConceptProposal[]> {
+  const proposals: ConceptProposal[] = [];
+  const conventions = readConventions();
+  const engine = createEngine(args.engine);
+
+  // Only process concepts with 3+ references (spec requirement)
+  const eligible = concepts.filter((c) => c.references.length >= 3);
+
+  for (const concept of eligible) {
+    console.error(
+      `   generating concept: ${concept.slug} (${concept.references.length} refs)`,
+    );
+
+    // Read referencing pages, truncated to 300 chars each
+    const referencingPages = concept.references
+      .map((ref) => {
+        try {
+          const content = readWikiFile(ref);
+          return `### ${ref}\n${content.slice(0, 300)}`;
+        } catch {
+          return `### ${ref}\n(could not read)`;
+        }
+      })
+      .join("\n\n");
+
+    const prompt = loadPrompt("lint-fix", {
+      mode: "concept",
+      conventions,
+      concept_slug: concept.slug,
+      referencing_pages: referencingPages,
+      // Mode B placeholders — empty when in concept mode
+      current_page: "",
+      raw_source: "",
+    });
+
+    if (args.dryRun) {
+      console.error(
+        `   [dry-run] would dispatch concept prompt (${prompt.length} chars)`,
+      );
+      continue;
+    }
+
+    try {
+      const response = await dispatchTask(engine, {
+        taskId: `lint-concept-${concept.slug}-${Date.now()}`,
+        prompt,
+        wikiRoot: WIKI_ROOT,
+        engineName: args.engine,
+        model: args.model || undefined,
+      });
+
+      if (response.error) {
+        console.error(
+          `   error for ${concept.slug}: ${response.error.message}`,
+        );
+        continue;
+      }
+
+      const parsed = parseJsonResponse<{
+        slug: string;
+        wiki_page_markdown: string;
+        index_entry: string;
+        related_updates: { path: string; add_related: string }[];
+      }>(response.output);
+
+      proposals.push({
+        type: "create_concept",
+        slug: parsed.slug || concept.slug,
+        content: parsed.wiki_page_markdown,
+        index_entry: parsed.index_entry,
+        related_updates: parsed.related_updates || [],
+      });
+
+      console.error(`   proposal ready: ${concept.slug}`);
+    } catch (e) {
+      console.error(`   failed for ${concept.slug}: ${(e as Error).message}`);
+    }
+  }
+
+  return proposals;
+}
+
+// ---------------------------------------------------------------------------
+// LLM proposal: todo_pages
+// ---------------------------------------------------------------------------
+
+async function proposeTodoRewrites(
+  todoPages: string[],
+  args: LintArgs,
+): Promise<RewriteProposal[]> {
+  const proposals: RewriteProposal[] = [];
+  const conventions = readConventions();
+  const engine = createEngine(args.engine);
+
+  for (const pagePath of todoPages) {
+    console.error(`   generating rewrite: ${pagePath}`);
+
+    let currentPage: string;
+    try {
+      currentPage = readWikiFile(pagePath);
+    } catch {
+      console.error(`   skipped ${pagePath} — could not read`);
+      continue;
+    }
+
+    // Extract raw source path from frontmatter sources: field
+    let rawSource = "";
+    const sourcesMatch = currentPage.match(
+      /^sources:\s*\n((?:\s+-\s+.+\n?)*)/m,
+    );
+    if (sourcesMatch) {
+      const sourceLines = sourcesMatch[1].trim().split("\n");
+      for (const line of sourceLines) {
+        const srcPath = line.replace(/^\s*-\s*/, "").trim();
+        if (srcPath) {
+          const absSourcePath = path.join(WIKI_ROOT, srcPath);
+          try {
+            rawSource += readFileSync(absSourcePath, "utf-8") + "\n";
+          } catch {
+            console.error(`   warning: could not read source ${srcPath}`);
+          }
+        }
+      }
+    }
+
+    if (!rawSource) {
+      // Try single-line sources: format
+      const singleMatch = currentPage.match(/^sources:\s*\[([^\]]*)\]/m);
+      if (singleMatch && singleMatch[1].trim()) {
+        const paths = singleMatch[1]
+          .split(",")
+          .map((s) => s.trim().replace(/['"]/g, ""));
+        for (const srcPath of paths) {
+          if (srcPath) {
+            const absSourcePath = path.join(WIKI_ROOT, srcPath);
+            try {
+              rawSource += readFileSync(absSourcePath, "utf-8") + "\n";
+            } catch {
+              console.error(`   warning: could not read source ${srcPath}`);
+            }
+          }
+        }
+      }
+    }
+
+    if (!rawSource) {
+      console.error(`   skipped ${pagePath} — no raw source found`);
+      continue;
+    }
+
+    const prompt = loadPrompt("lint-fix", {
+      mode: "rewrite",
+      conventions,
+      concept_slug: "",
+      referencing_pages: "",
+      current_page: currentPage,
+      raw_source: rawSource,
+    });
+
+    if (args.dryRun) {
+      console.error(
+        `   [dry-run] would dispatch rewrite prompt (${prompt.length} chars)`,
+      );
+      continue;
+    }
+
+    try {
+      const response = await dispatchTask(engine, {
+        taskId: `lint-rewrite-${path.basename(pagePath, ".md")}-${Date.now()}`,
+        prompt,
+        wikiRoot: WIKI_ROOT,
+        engineName: args.engine,
+        model: args.model || undefined,
+      });
+
+      if (response.error) {
+        console.error(`   error for ${pagePath}: ${response.error.message}`);
+        continue;
+      }
+
+      const parsed = parseJsonResponse<{
+        wiki_page_markdown: string;
+        index_entry: string;
+      }>(response.output);
+
+      proposals.push({
+        type: "rewrite_page",
+        path: pagePath,
+        content: parsed.wiki_page_markdown,
+        index_entry: parsed.index_entry,
+      });
+
+      console.error(`   proposal ready: ${pagePath}`);
+    } catch (e) {
+      console.error(`   failed for ${pagePath}: ${(e as Error).message}`);
+    }
+  }
+
+  return proposals;
+}
+
+// ---------------------------------------------------------------------------
+// Apply proposals
+// ---------------------------------------------------------------------------
+
+function applyProposals(proposals: Proposal[]): {
+  concept_pages: number;
+  rewrites: number;
+} {
+  let conceptPages = 0;
+  let rewrites = 0;
+
+  for (const proposal of proposals) {
+    switch (proposal.type) {
+      case "create_concept": {
+        const p = proposal as ConceptProposal;
+        const pagePath = `concepts/${p.slug}.md`;
+        console.error(`   writing concept page: ${pagePath}`);
+        writeWikiFile(pagePath, p.content);
+
+        // Apply related_updates — add cross-references to referencing pages
+        for (const update of p.related_updates) {
+          if (!wikiFileExists(update.path)) {
+            console.error(
+              `   skipped related update: ${update.path} not found`,
+            );
+            continue;
+          }
+          let content = readWikiFile(update.path);
+          // Add to frontmatter related: list if not already present
+          if (!content.includes(update.add_related)) {
+            content = content.replace(
+              /^(related:\s*\n)/m,
+              `$1  - ${update.add_related}\n`,
+            );
+            writeWikiFile(update.path, content);
+            console.error(`   updated related in ${update.path}`);
+          }
+        }
+
+        // Add to index.md
+        if (p.index_entry) {
+          appendToIndex(p.index_entry, "concepts");
+        }
+
+        // Append to log.md
+        appendToLog(
+          `Created concept page concepts/${p.slug}.md via lint --apply`,
+        );
+
+        conceptPages++;
+        break;
+      }
+
+      case "rewrite_page": {
+        const p = proposal as RewriteProposal;
+        console.error(`   rewriting page: ${p.path}`);
+        writeWikiFile(p.path, p.content);
+
+        // Update index entry if provided
+        if (p.index_entry) {
+          const category = p.path.split("/")[0];
+          updateIndexEntry(p.path, p.index_entry, category);
+        }
+
+        appendToLog(`Rewrote TODO page ${p.path} via lint --apply`);
+        rewrites++;
+        break;
+      }
+
+      case "stale_warning":
+        // Stale warnings are informational only — no action
+        break;
+    }
+  }
+
+  return { concept_pages: conceptPages, rewrites };
+}
+
+// ---------------------------------------------------------------------------
+// Index and log helpers
+// ---------------------------------------------------------------------------
+
+function appendToIndex(entry: string, category: string): void {
+  const indexPath = path.join(WIKI_DIR, "index.md");
+  let content = readFileSync(indexPath, "utf-8");
+
+  const categoryHeadings: Record<string, string> = {
+    ops: "## Ops",
+    architecture: "## Architecture",
+    training: "## Training",
+    infra: "## Infra",
+    tools: "## Tools",
+    product: "## Product",
+    concepts: "## Concepts",
+  };
+
+  const heading = categoryHeadings[category];
+  if (!heading) return;
+
+  const headingIdx = content.indexOf(heading);
+  if (headingIdx === -1) {
+    content += `\n\n${heading}\n\n${entry}\n`;
+  } else {
+    const afterHeading = content.indexOf("\n", headingIdx);
+    const nextHeading = content.indexOf("\n## ", afterHeading + 1);
+    const insertPos = nextHeading === -1 ? content.length : nextHeading;
+    const before = content.slice(0, insertPos).trimEnd();
+    const after = content.slice(insertPos);
+    content = before + "\n" + entry + "\n" + after;
+  }
+
+  writeFileSync(indexPath, content, "utf-8");
+}
+
+function updateIndexEntry(
+  pagePath: string,
+  newEntry: string,
+  category: string,
+): void {
+  const indexPath = path.join(WIKI_DIR, "index.md");
+  let content = readFileSync(indexPath, "utf-8");
+
+  // Try to find existing entry for this page and replace it
+  const escaped = pagePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const entryPattern = new RegExp(`^- \\[.*\\]\\(${escaped}\\).*$`, "m");
+  const match = content.match(entryPattern);
+
+  if (match) {
+    content = content.replace(entryPattern, newEntry);
+    writeFileSync(indexPath, content, "utf-8");
+  } else {
+    // Entry doesn't exist yet — append under the correct category
+    appendToIndex(newEntry, category);
+  }
+}
+
+function appendToLog(message: string): void {
+  const logPath = path.join(WIKI_DIR, "log.md");
+  if (!existsSync(logPath)) return;
+
+  const date = new Date().toISOString().slice(0, 10);
+  const entry = `[${date}] ${message}`;
+  let content = readFileSync(logPath, "utf-8");
+  content = content.trimEnd() + "\n" + entry + "\n";
+  writeFileSync(logPath, content, "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const args = parseLintArgs();
+
+  console.error(`Wiki:     ${WIKI_ROOT}`);
+  console.error(
+    `Engine:   ${args.engine}${args.model ? ` (${args.model})` : ""}`,
+  );
+  console.error(
+    `Mode:     ${args.apply ? "apply" : args.fix ? "fix" : "report"}`,
+  );
+  if (args.category) console.error(`Category: ${args.category}`);
+  console.error("");
+
+  // 1. Run lw lint
+  console.error("🔍 Running lw lint...");
+  const report = runLint(args.category);
+
+  const findingCounts = {
+    broken_related: report.broken_related.length,
+    orphan_pages: report.orphan_pages.length,
+    missing_concepts: report.missing_concepts.length,
+    todo_pages: report.todo_pages.length,
+    stale_pages: report.freshness.stale_pages.length,
+  };
+  const total = Object.values(findingCounts).reduce((a, b) => a + b, 0);
+
+  console.error(`   broken_related:  ${findingCounts.broken_related}`);
+  console.error(`   orphan_pages:    ${findingCounts.orphan_pages}`);
+  console.error(`   missing_concepts: ${findingCounts.missing_concepts}`);
+  console.error(`   todo_pages:      ${findingCounts.todo_pages}`);
+  console.error(`   stale_pages:     ${findingCounts.stale_pages}`);
+  console.error(`   total:           ${total}`);
+  console.error("");
+
+  // ---------------------------------------------------------------------------
+  // Report mode — output findings and exit
+  // ---------------------------------------------------------------------------
+  if (!args.fix) {
+    console.log(JSON.stringify({ findings: findingCounts, total }, null, 2));
+    return;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fix mode — auto-fix simple issues
+  // ---------------------------------------------------------------------------
+  console.error("🔧 Auto-fixing simple issues...");
+
+  const autoFixed: Record<string, number> = {};
+
+  // Auto-fix broken_related
+  if (report.broken_related.length > 0) {
+    console.error(`\n   broken_related (${report.broken_related.length}):`);
+    autoFixed.broken_related = fixBrokenRelated(report.broken_related);
+  }
+
+  // Auto-fix orphan_pages
+  if (report.orphan_pages.length > 0) {
+    console.error(`\n   orphan_pages (${report.orphan_pages.length}):`);
+    autoFixed.orphan_pages = fixOrphanPages(report.orphan_pages);
+  }
+
+  console.error("\n   auto-fix complete.");
+  console.error("");
+
+  // ---------------------------------------------------------------------------
+  // Fix mode — generate LLM proposals
+  // ---------------------------------------------------------------------------
+  const proposals: Proposal[] = [];
+
+  // Missing concepts
+  if (report.missing_concepts.length > 0) {
+    console.error(
+      `🤖 Generating concept proposals (${report.missing_concepts.length} concepts)...`,
+    );
+    const conceptProposals = await proposeMissingConcepts(
+      report.missing_concepts,
+      args,
+    );
+    proposals.push(...conceptProposals);
+    console.error("");
+  }
+
+  // TODO pages
+  if (report.todo_pages.length > 0) {
+    console.error(
+      `🤖 Generating rewrite proposals (${report.todo_pages.length} TODO pages)...`,
+    );
+    const rewriteProposals = await proposeTodoRewrites(report.todo_pages, args);
+    proposals.push(...rewriteProposals);
+    console.error("");
+  }
+
+  // Stale pages — collect as warnings only
+  if (report.freshness.stale_pages.length > 0) {
+    proposals.push({
+      type: "stale_warning",
+      paths: report.freshness.stale_pages,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Fix mode (no --apply) — output proposals as JSON
+  // ---------------------------------------------------------------------------
+  if (!args.apply) {
+    const output = {
+      auto_fixed: autoFixed,
+      proposals: proposals
+        .filter((p) => p.type !== "stale_warning")
+        .map((p) => {
+          if (p.type === "create_concept") {
+            const cp = p as ConceptProposal;
+            return {
+              type: cp.type,
+              slug: cp.slug,
+              references: cp.related_updates.length,
+              preview: cp.content.slice(0, 200),
+            };
+          }
+          if (p.type === "rewrite_page") {
+            const rp = p as RewriteProposal;
+            return {
+              type: rp.type,
+              path: rp.path,
+              preview: rp.content.slice(0, 200),
+            };
+          }
+          return p;
+        }),
+      stale_warnings: report.freshness.stale_pages,
+    };
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Apply mode — execute proposals
+  // ---------------------------------------------------------------------------
+  console.error("📝 Applying proposals...");
+  const applied = applyProposals(proposals);
+
+  console.error(
+    `\n   applied: ${applied.concept_pages} concept pages, ${applied.rewrites} rewrites`,
+  );
+  console.error("");
+
+  // Re-run lint to verify
+  console.error("🔍 Re-running lw lint to verify...");
+  let lintAfter: string;
+  try {
+    const verifyReport = runLint(args.category);
+    const remaining =
+      verifyReport.broken_related.length +
+      verifyReport.orphan_pages.length +
+      verifyReport.missing_concepts.length +
+      verifyReport.todo_pages.length;
+    lintAfter =
+      remaining === 0 ? "All clear!" : `${remaining} findings remaining`;
+    console.error(`   ${lintAfter}`);
+  } catch (e) {
+    lintAfter = `lint re-run failed: ${(e as Error).message}`;
+    console.error(`   ${lintAfter}`);
+  }
+
+  // Output summary
+  const output = {
+    auto_fixed: autoFixed,
+    applied: {
+      concept_pages: applied.concept_pages,
+      rewrites: applied.rewrites,
+    },
+    stale_warnings: report.freshness.stale_pages,
+    lint_after: lintAfter,
+  };
+  console.log(JSON.stringify(output, null, 2));
+}
+
+main().catch((e) => {
+  console.error(`\n${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -111,36 +111,88 @@ export function createEngine(name: string): Engine {
 // JSON response parsing
 // ---------------------------------------------------------------------------
 
+/**
+ * Fix raw newlines inside JSON string values.
+ * LLMs often output {"key":"line1\nline2"} with actual newline chars,
+ * which is illegal JSON (must be \\n). This repairs them.
+ */
+function fixRawNewlinesInJson(text: string): string {
+  // Replace raw newlines that appear inside JSON string values.
+  // Strategy: walk through the string tracking quote state.
+  let result = "";
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) {
+      result += ch;
+      escape = false;
+      continue;
+    }
+    if (ch === "\\" && inString) {
+      result += ch;
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      result += ch;
+      continue;
+    }
+    if (inString && ch === "\n") {
+      result += "\\n";
+      continue;
+    }
+    if (inString && ch === "\r") {
+      result += "\\r";
+      continue;
+    }
+    if (inString && ch === "\t") {
+      result += "\\t";
+      continue;
+    }
+    result += ch;
+  }
+  return result;
+}
+
+function tryParse<T>(text: string): T | undefined {
+  try {
+    return JSON.parse(text) as T;
+  } catch {}
+  // Retry with newline fix
+  try {
+    return JSON.parse(fixRawNewlinesInJson(text)) as T;
+  } catch {}
+  return undefined;
+}
+
 export function parseJsonResponse<T>(output: string): T {
   // Tier 1: direct parse
-  try {
-    return JSON.parse(output) as T;
-  } catch {}
+  const t1 = tryParse<T>(output);
+  if (t1 !== undefined) return t1;
 
   // Tier 2: markdown code block
   const codeBlockMatch = output.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
   if (codeBlockMatch) {
-    try {
-      return JSON.parse(codeBlockMatch[1]) as T;
-    } catch {}
+    const t2 = tryParse<T>(codeBlockMatch[1]);
+    if (t2 !== undefined) return t2;
   }
 
   // Tier 3a: array bracket search
   const arrStart = output.indexOf("[");
   const arrEnd = output.lastIndexOf("]");
   if (arrStart !== -1 && arrEnd > arrStart) {
-    try {
-      return JSON.parse(output.slice(arrStart, arrEnd + 1)) as T;
-    } catch {}
+    const t3a = tryParse<T>(output.slice(arrStart, arrEnd + 1));
+    if (t3a !== undefined) return t3a;
   }
 
   // Tier 3b: object bracket search
   const objStart = output.indexOf("{");
   const objEnd = output.lastIndexOf("}");
   if (objStart !== -1 && objEnd > objStart) {
-    try {
-      return JSON.parse(output.slice(objStart, objEnd + 1)) as T;
-    } catch {}
+    const t3b = tryParse<T>(output.slice(objStart, objEnd + 1));
+    if (t3b !== undefined) return t3b;
   }
 
   throw new Error("Could not parse LLM response as JSON");

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,192 @@
+/**
+ * shared.ts — Common utilities for all llm-wiki agents
+ *
+ * Extracted from classify.ts. Provides:
+ *   - BaseArgs interface + parseBaseArgs()
+ *   - WIKI_ROOT constant
+ *   - lw() CLI wrapper
+ *   - createEngine() factory
+ *   - parseJsonResponse<T>() — handles both [] and {} responses
+ *   - loadPrompt() — template loading with {{placeholder}} replacement
+ *   - dispatchTask() — standard codebridge task submission
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { ClaudeCodeEngine } from "codebridge/src/engines/claude-code.js";
+import { KimiCodeEngine } from "codebridge/src/engines/kimi-code.js";
+import { CodexEngine } from "codebridge/src/engines/codex.js";
+import { OpenCodeEngine } from "codebridge/src/engines/opencode.js";
+import type { Engine, EngineResponse } from "codebridge/src/core/engine.js";
+
+export type { Engine, EngineResponse };
+
+// ---------------------------------------------------------------------------
+// WIKI_ROOT
+// ---------------------------------------------------------------------------
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export const WIKI_ROOT: string =
+  process.env.LW_WIKI_ROOT ||
+  process.env.WIKI_ROOT ||
+  path.resolve(__dirname, "../../wiki");
+
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+
+export interface BaseArgs {
+  engine: string;
+  model: string;
+  batch: number;
+  dryRun: boolean;
+}
+
+export function parseBaseArgs(defaults: Partial<BaseArgs>): BaseArgs {
+  const args = process.argv.slice(2);
+  const opts: BaseArgs = {
+    engine: defaults.engine ?? "claude-code",
+    model: defaults.model ?? "",
+    batch: defaults.batch ?? 20,
+    dryRun: defaults.dryRun ?? false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case "--engine":
+      case "-e":
+        opts.engine = args[++i];
+        break;
+      case "--model":
+      case "-m":
+        opts.model = args[++i];
+        break;
+      case "--batch":
+      case "-b":
+        opts.batch = parseInt(args[++i], 10);
+        break;
+      case "--dry-run":
+        opts.dryRun = true;
+        break;
+    }
+  }
+  return opts;
+}
+
+// ---------------------------------------------------------------------------
+// lw CLI wrapper
+// ---------------------------------------------------------------------------
+
+export function lw(cmd: string): string {
+  return execSync(`lw ${cmd} --root "${WIKI_ROOT}"`, {
+    encoding: "utf-8",
+    timeout: 30_000,
+  }).trim();
+}
+
+// ---------------------------------------------------------------------------
+// Engine factory
+// ---------------------------------------------------------------------------
+
+export function createEngine(name: string): Engine {
+  switch (name) {
+    case "claude-code":
+      return new ClaudeCodeEngine();
+    case "kimi-code":
+      return new KimiCodeEngine();
+    case "codex":
+      return new CodexEngine();
+    case "opencode":
+      return new OpenCodeEngine();
+    default:
+      throw new Error(
+        `Unknown engine: ${name}. Supported: claude-code, kimi-code, codex, opencode`,
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// JSON response parsing
+// ---------------------------------------------------------------------------
+
+export function parseJsonResponse<T>(output: string): T {
+  // Tier 1: direct parse
+  try {
+    return JSON.parse(output) as T;
+  } catch {}
+
+  // Tier 2: markdown code block
+  const codeBlockMatch = output.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+  if (codeBlockMatch) {
+    try {
+      return JSON.parse(codeBlockMatch[1]) as T;
+    } catch {}
+  }
+
+  // Tier 3a: array bracket search
+  const arrStart = output.indexOf("[");
+  const arrEnd = output.lastIndexOf("]");
+  if (arrStart !== -1 && arrEnd > arrStart) {
+    try {
+      return JSON.parse(output.slice(arrStart, arrEnd + 1)) as T;
+    } catch {}
+  }
+
+  // Tier 3b: object bracket search
+  const objStart = output.indexOf("{");
+  const objEnd = output.lastIndexOf("}");
+  if (objStart !== -1 && objEnd > objStart) {
+    try {
+      return JSON.parse(output.slice(objStart, objEnd + 1)) as T;
+    } catch {}
+  }
+
+  throw new Error("Could not parse LLM response as JSON");
+}
+
+// ---------------------------------------------------------------------------
+// Prompt template loading
+// ---------------------------------------------------------------------------
+
+export function loadPrompt(name: string, vars: Record<string, string>): string {
+  const templatePath = path.join(__dirname, "../prompts", `${name}.md`);
+  let template = readFileSync(templatePath, "utf-8");
+  for (const [key, value] of Object.entries(vars)) {
+    template = template.replaceAll(`{{${key}}}`, value);
+  }
+  return template;
+}
+
+// ---------------------------------------------------------------------------
+// Standard task dispatch
+// ---------------------------------------------------------------------------
+
+export async function dispatchTask(
+  engine: Engine,
+  opts: {
+    taskId: string;
+    prompt: string;
+    wikiRoot: string;
+    engineName: string;
+    model?: string;
+    timeoutMs?: number;
+  },
+): Promise<EngineResponse> {
+  return engine.start({
+    task_id: opts.taskId,
+    intent: "ops",
+    workspace_path: opts.wikiRoot,
+    message: opts.prompt,
+    engine: opts.engineName as any,
+    model: opts.model || undefined,
+    mode: "new",
+    session_id: null,
+    constraints: {
+      timeout_ms: opts.timeoutMs ?? 300_000,
+      allow_network: true,
+    },
+    images: [],
+  });
+}


### PR DESCRIPTION
## Summary

Implements the two missing agents per design spec (Pawpaw-Technology/llm-wiki-mono#9):

**shared.ts** — Extracted from classify.ts: `parseBaseArgs`, `lw()`, `createEngine()`, `parseJsonResponse<T>` (generalized for `{}` and `[]`), `loadPrompt()`, `dispatchTask()`

**ingest.ts** — Batch-ingest raw sources into wiki pages
- Auto-scan `raw/` for unprocessed sources, or `--source <glob>` for explicit
- Sequential processing with index.md re-read per iteration
- Validation: slug ≤60, valid category, frontmatter check
- Skip-on-error: LLM/parse/validation failures recorded, continues

**lint.ts** — Three-mode wiki health check
- Report: `lw lint --format json` → findings summary
- Fix (`--fix`): auto-fix broken_related (bigram similarity) + orphan_pages (index append) + LLM proposals for missing_concepts and todo_pages
- Apply (`--fix --apply`): execute proposals + re-run lint to verify

Also: classify.ts refactored to import shared, `librarian` script removed, `ingest` script added.

Closes Pawpaw-Technology/llm-wiki-agents#1
Closes Pawpaw-Technology/llm-wiki-agents#2

## Test results
- `npx tsx src/ingest.ts --dry-run` → PASS (scanned 33 raw files, all ingested)
- `npx tsx src/lint.ts` → PASS (report mode, found 1 broken_related)
- `npx tsx src/lint.ts --fix` → PASS (auto-removed stale broken link)
- `npx tsc --noEmit --skipLibCheck` → zero errors in src/

## Test plan
- [x] ingest --dry-run smoke test
- [x] lint report mode smoke test
- [x] lint --fix auto-repair smoke test
- [x] typecheck clean
- [ ] Live ingest test with a real raw source
- [ ] lint --fix --apply with missing concept

🤖 Generated with [Claude Code](https://claude.com/claude-code)